### PR TITLE
support "server" directive in main context

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently supported directives per context:
 
 * main:
   * http
+  * server
 * http:
   * server
 * server:

--- a/nginxadapter.go
+++ b/nginxadapter.go
@@ -85,6 +85,8 @@ func (ss *setupState) mainContext(dirs []Directive) ([]caddyconfig.Warning, erro
 		switch dir.Name() {
 		case "http":
 			warns, err = ss.httpContext(dir.Block)
+		case "server":
+			warns, err = ss.serverContext(dir.Block)
 		default:
 			warns = []caddyconfig.Warning{
 				{

--- a/server.go
+++ b/server.go
@@ -99,7 +99,7 @@ nextDirective:
 						Directive: dir.Name(),
 						Message:   ErrNamedLocation,
 					})
-					return warnings, nil
+					continue nextDirective
 				}
 				// append wild character because nginx treat naked path matchers as prefix matchers
 				matcher = caddyhttp.MatchPath([]string{dir.Param(1) + "*"})
@@ -116,7 +116,8 @@ nextDirective:
 			// encode the matchers then set the result as raw matcher config
 			matcherSetsEnc, err = encodeMatcherSets(locationMatcherSet)
 			if err != nil {
-				return nil, err
+				warnings = append(warnings, warns...)
+				return warnings, err
 			}
 			// set the matcher to route
 			route.MatcherSetsRaw = matcherSetsEnc


### PR DESCRIPTION
As per issue #2, it seems that the `server` directive is expected to be used in the main context. This should resolve that part.

As for `map`, Caddy doesn't currently have an equivalent for it (caddyserver/caddy#2824). It can probably be supported within the adapter, but that'd be a tad complex.

Updates #2 