### PR TITLE
provide helper script to build Caddy with nginx adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,25 @@ Thank you, and we hope you have fun with it!
 
 **Note: This module is only compatible with Caddy 2, which is currently in beta.**
 
-First, go get this module:
+First, clone this repository:
 
 ```
-$ go get github.com/caddyserver/nginx-adapter
+$ git clone github.com/caddyserver/nginx-adapter caddy-nginx-adapter
 ```
 
-To compile, simply `go build` Caddy 2 with this adapter plugged in. Add this to the list of imports:
+Move into the cloned directory:
 
 ```
-	_ "github.com/caddyserver/nginx-adapter"
+$ cd caddy-nginx-adapter
 ```
 
 Then run:
 
 ```
-$ go build
+$ ./build_caddy.sh
 ```
 
+The script will create a directory named `caddy`, and the custom built Caddy executable is inside it and named `caddy_v2`.
 
 ## Use
 

--- a/build_caddy.sh
+++ b/build_caddy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir caddy || true
+cd caddy || true
+curl "https://raw.githubusercontent.com/caddyserver/caddy/v2/cmd/caddy/main.go" > main.go
+sed -i.bak 's/^)/	_ "github.com\/caddyserver\/nginx-adapter"\'$'\n)/' main.go && rm main.go.bak
+
+go mod init caddy
+grep 'require' ../go.mod >> go.mod
+go build

--- a/build_caddy.sh
+++ b/build_caddy.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-mkdir caddy || true
-cd caddy || true
+set -euxo pipefail
+
+# Get the Caddy version currenly used for the adapter
+CADDY_VERSION=$(go list -m github.com/caddyserver/caddy/v2 | cut -d " " -f 2)
+
+mkdir -p caddy
+cd caddy
 curl "https://raw.githubusercontent.com/caddyserver/caddy/v2/cmd/caddy/main.go" > main.go
 sed -i.bak 's/^)/	_ "github.com\/caddyserver\/nginx-adapter"\'$'\n)/' main.go && rm main.go.bak
 
 go mod init caddy
-grep 'require' ../go.mod >> go.mod
-go build
+go mod edit -require=github.com/caddyserver/caddy/v2@"$CADDY_VERSION"
+go build -o caddy_v2


### PR DESCRIPTION
There have been 2 reports (#5 and https://caddy.community/t/howto-use-nginx-config-adapter/6929) of difficulties to build Caddy with the nginx adapter. This PR provides a helper script to do just that.