### PR TITLE
Fix handling of the `include` directive

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -94,10 +94,12 @@ func (p *nginxParser) next() (Directive, error) {
 			if err != nil {
 				return Directive{}, err
 			}
+			tkn = p.tokens[p.cursor]
+			dir.File = tkn.file
+			dir.Line = tkn.line
 		}
 		dir.Params = append(dir.Params, tkn.text)
 	}
-
 	return dir, nil
 }
 
@@ -184,13 +186,12 @@ func (p *nginxParser) doInclude() error {
 
 	// splice out the import directive and its argument (2 tokens total)
 	tokensBefore := p.tokens[:p.cursor-1]
-	tokensAfter := p.tokens[p.cursor+1:]
+	tokensAfter := p.tokens[p.cursor+2:]
 
 	// splice the imported tokens in the place of the import statement
 	// and rewind cursor so Next() will land on first imported token
 	p.tokens = append(tokensBefore, append(importedTokens, tokensAfter...)...)
 	p.cursor--
-
 	return nil
 }
 

--- a/testdata/example1.conf
+++ b/testdata/example1.conf
@@ -1,4 +1,4 @@
-# from: https://www.nginx.com/resources/wiki/start/topics/examples/full/
+# adapted from: https://www.nginx.com/resources/wiki/start/topics/examples/full/
 
 user       www www;  ## Default: nobody
 worker_processes  5;  ## Default: 1
@@ -11,9 +11,8 @@ events {
 }
 
 http {
-  include    conf/mime.types;
-  include    /etc/nginx/proxy.conf;
-  include    /etc/nginx/fastcgi.conf;
+  # the modified line from 
+  include   example2.conf;
   index    index.html index.htm index.php;
 
   default_type application/octet-stream;

--- a/testdata/example2.conf
+++ b/testdata/example2.conf
@@ -1,0 +1,10 @@
+server {
+  listen       80;
+  server_name  domain3.com www.domain3.com;
+  access_log   logs/domain3.access.log  main;
+  root         html;
+
+  location ~ \.php$ {
+    fastcgi_pass   127.0.0.1:1025;
+  }
+}


### PR DESCRIPTION
The bug in handling of the `include` directive is two parts:

- The `doInclude` method almost spliced the token set correctly, if it weren't for an off-by-one error.

- After importing and splicing the token set, the current wasn't updated to token from the included file. So the same `include` token became the active directive in that loop.