### PR TITLE
upstream: truly handle the `upstream` directive

### DIFF
--- a/nginxadapter.go
+++ b/nginxadapter.go
@@ -111,6 +111,16 @@ func (ss *setupState) httpContext(dirs []Directive) ([]caddyconfig.Warning, erro
 		switch dir.Name() {
 		case "server":
 			warns, err = ss.serverContext(dir.Block)
+		case "upstream":
+			up, w, err := ss.upstreamContext(dir.Block)
+			warns = append(warns, w...)
+			if err != nil {
+				return warns, err
+			}
+			if ss.upstreams == nil {
+				ss.upstreams = make(map[string]Upstream)
+			}
+			ss.upstreams[dir.Param(1)] = up
 		default:
 			warns = []caddyconfig.Warning{
 				{


### PR DESCRIPTION
The code to handle the `upstream` directive was present, but never wired up. This commit wires up the implementation, and fixes an a bug in setting up the upstream address.

Fixes #17 